### PR TITLE
Fixed Warnings throwed by array_key_exists

### DIFF
--- a/lib/OpenNode.php
+++ b/lib/OpenNode.php
@@ -80,7 +80,7 @@ class OpenNode
         $response    = json_decode(curl_exec($curl), TRUE);
         $http_status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-        if (array_key_exists('data', $response)){
+        if (is_array($response) && array_key_exists('data', $response)){
             return $response['data'];
         }
         else {


### PR DESCRIPTION
array_key_exists throwed Warnings, when $response variable passed to it wasn't array